### PR TITLE
Add further information about usage in CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To add OpenSSL in your QMake project, append the following to your `.pro` projec
 android: include(<path/to/android_openssl/openssl.pri)
 ```
 
-To add OpenSSL in your CMake project, append the following to your project's `CMakeLists.txt` file:
+To add OpenSSL in your CMake project, append the following to your project's `CMakeLists.txt` file, anywhere before the find_package() call for Qt5 modules:
 
 ```
 if (ANDROID)


### PR DESCRIPTION
Tested in Qt 5.15.0-beta4.

Running 'make apk' or 'make aab' properly add libcrypto.so and libssl.so in app's bundle.